### PR TITLE
Add functions to retrieve HTTP status and format domain name. Renamed Interface IDomainInfo to DomainInfo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.0] - 2023-05-23
+
+### Breaking
+
+- The `IDomainInfo` interface has been renamed to `DomainInfo` so the `fetchDomainInfo` function now returns a `DomainInfo` object instead of an `IDomainInfo` object.
+
+### Updated
+
+- Updated the README.md
+- Updated the package.json keywords
+- Updated the package.json description
+- Updated the installed packages to the latest version
+
+### Added
+
+- New HTTP Status Codes to the DomainInfo Object
+- Domains will now be formatted to lowercase before fetching the information
+- Domains that start with `http://`, `https://` or `www` will now be stripped of the protocol before fetching the information
+- New Tests for the new HTTP Status Codes
+
 ## [1.0.8] - 2023-03-19
 
 ### Updated

--- a/README.md
+++ b/README.md
@@ -17,14 +17,18 @@ npm install domain-info-fetcher
 ### TypeScript
 
 ```typescript
-import { fetchDomainInfo, IDomainInfo } from 'domain-info-fetcher';
+import { fetchDomainInfo } from 'domain-info-fetcher';
 
 async function main() {
-  const domainInfo: IDomainInfo | undefined = await fetchDomainInfo('example.com');
+  const domainInfo = await fetchDomainInfo('example.com');
+
   if (domainInfo) {
     console.log('SSL Data:', domainInfo.sslData);
     console.log('Server Data:', domainInfo.serverData);
     console.log('DNS Data:', domainInfo.dnsData);
+    console.log('HTTP Status:', domainInfo.httpStatus);
+  } else {
+    console.error('Error fetching domain information');
   }
 }
 
@@ -38,10 +42,14 @@ const { fetchDomainInfo } = require('domain-info-fetcher');
 
 async function main() {
   const domainInfo = await fetchDomainInfo('example.com');
+  
   if (domainInfo) {
     console.log('SSL Data:', domainInfo.sslData);
     console.log('Server Data:', domainInfo.serverData);
     console.log('DNS Data:', domainInfo.dnsData);
+    console.log('HTTP Status:', domainInfo.httpStatus);
+  } else {
+    console.error('Error fetching domain information');
   }
 }
 
@@ -50,7 +58,7 @@ main();
 
 ## API
 
-### `fetchDomainInfo(domain: string): Promise<IDomainInfo | undefined>`
+### `fetchDomainInfo(domain: string): Promise<DomainInfo | undefined>`
 
 Fetches the SSL, server and DNS information of the given domain.
 
@@ -65,15 +73,16 @@ Returns a promise that resolves to an object with the following properties:
 | `sslData` | The SSL certificate data of the domain. |
 | `serverData` | The server software used by the domain. (if available) |
 | `dnsData` | The DNS records of the domain. |
+| `httpStatus` | The HTTP status code of the domain. |
 
 Returns `undefined` if an error occurs while fetching the domain information.
 
-### `IDomainInfo`
+### `DomainInfo`
 
 The interface for the object returned by `fetchDomainInfo`.
 
 ```typescript
-interface IDomainInfo {
+interface DomainInfo {
   sslData: any;
   serverData: string | undefined;
   dnsData: {
@@ -84,6 +93,7 @@ interface IDomainInfo {
     NS: string[];
     SOA: dns.SoaRecord | null;
   };
+  httpStatus: number;
 }
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,22 +1,22 @@
 {
   "name": "domain-info-fetcher",
-  "version": "1.0.0",
+  "version": "1.0.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "domain-info-fetcher",
-      "version": "1.0.0",
-      "license": "ISC",
+      "version": "1.0.8",
+      "license": "MIT",
       "dependencies": {
         "ts-node": "^10.9.1",
-        "typescript": "^5.0.2"
+        "typescript": "^5.0.4"
       },
       "devDependencies": {
-        "@types/jest": "^29.5.0",
+        "@types/jest": "^29.5.1",
         "@types/node": "^18.15.3",
         "jest": "^29.5.0",
-        "ts-jest": "^29.0.5"
+        "ts-jest": "^29.1.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -1122,9 +1122,9 @@
       }
     },
     "node_modules/@types/jest": {
-      "version": "29.5.0",
-      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.5.0.tgz",
-      "integrity": "sha512-3Emr5VOl/aoBwnWcH/EFQvlSAmjV+XtV9GGu5mwdYew5vhQh0IUZx/60x0TzHDu09Bi7HMx10t/namdJw5QIcg==",
+      "version": "29.5.1",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.5.1.tgz",
+      "integrity": "sha512-tEuVcHrpaixS36w7hpsfLBLpjtMRJUE09/MHXn923LOVojDwyC14cWcfc0rDs0VEfUyYmt/+iX1kxxp+gZMcaQ==",
       "dev": true,
       "dependencies": {
         "expect": "^29.0.0",
@@ -3410,9 +3410,9 @@
       }
     },
     "node_modules/ts-jest": {
-      "version": "29.0.5",
-      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.0.5.tgz",
-      "integrity": "sha512-PL3UciSgIpQ7f6XjVOmbi96vmDHUqAyqDr8YxzopDqX3kfgYtX1cuNeBjP+L9sFXi6nzsGGA6R3fP3DDDJyrxA==",
+      "version": "29.1.0",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.1.0.tgz",
+      "integrity": "sha512-ZhNr7Z4PcYa+JjMl62ir+zPiNJfXJN6E8hSLnaUKhOgqcn8vb3e537cpkd0FuAfRK3sR1LSqM1MOhliXNgOFPA==",
       "dev": true,
       "dependencies": {
         "bs-logger": "0.x",
@@ -3435,7 +3435,7 @@
         "@jest/types": "^29.0.0",
         "babel-jest": "^29.0.0",
         "jest": "^29.0.0",
-        "typescript": ">=4.3"
+        "typescript": ">=4.3 <6"
       },
       "peerDependenciesMeta": {
         "@babel/core": {
@@ -3549,9 +3549,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.2.tgz",
-      "integrity": "sha512-wVORMBGO/FAs/++blGNeAVdbNKtIh1rbBL2EyQ1+J9lClJ93KiiKe8PmFIVdXhHcyv44SL9oglmfeSsndo0jRw==",
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.4.tgz",
+      "integrity": "sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "domain-info-fetcher",
-  "version": "1.0.8",
-  "description": "A package to fetch information about a domain including SSL certificate, server, and DNS records",
+  "version": "1.1.0",
+  "description": "A package to fetch information about a domain including SSL/TLS certificate, server informations, DNS records and HTTP status codes",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "repository": {
@@ -13,12 +13,16 @@
     "test": "jest"
   },
   "keywords": [
-    "domain",
+    "Domain infos",
+    "SSL certificate",
     "SSL",
-    "certificate",
-    "server",
+    "TLS certificate",
+    "TLS",
+    "server info",
+    "DNS records",
     "DNS",
-    "records"
+    "HTTP status codes",
+    "HTTP"
   ],
   "author": " Marcel Baklouti <marcel@baklouti.de>",
   "license": "MIT",
@@ -28,12 +32,12 @@
   "homepage": "https://github.com/marcelbaklouti/domain-info-fetcher#readme",
   "dependencies": {
     "ts-node": "^10.9.1",
-    "typescript": "^5.0.2"
+    "typescript": "^5.0.4"
   },
   "devDependencies": {
-    "@types/jest": "^29.5.0",
+    "@types/jest": "^29.5.1",
     "@types/node": "^18.15.3",
     "jest": "^29.5.0",
-    "ts-jest": "^29.0.5"
+    "ts-jest": "^29.1.0"
   }
 }

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,18 +1,35 @@
 import { fetchDomainInfo } from '../index';
 
-describe('fetchDomainInfo', () => {
+describe('fetchDomainInfo function', () => {
   test('fetches domain info for baklouti.de', async () => {
     const domainInfo = await fetchDomainInfo('baklouti.de');
-
-    expect(domainInfo).toHaveProperty('sslData');
-    expect(domainInfo).toHaveProperty('serverData');
-    expect(domainInfo).toHaveProperty('dnsData');
-    expect(domainInfo?.dnsData).toHaveProperty('A');
-    expect(domainInfo?.dnsData).toHaveProperty('CNAME');
-    expect(domainInfo?.dnsData).toHaveProperty('TXT');
-    expect(domainInfo?.dnsData).toHaveProperty('MX');
-    expect(domainInfo?.dnsData).toHaveProperty('NS');
-    expect(domainInfo?.dnsData).toHaveProperty('SOA');
+    expect(domainInfo).toBeDefined();
   });
+
+  test('fetches domain info for https://baklouti.de', async () => {
+    const domainInfo = await fetchDomainInfo('https://baklouti.de');
+    expect(domainInfo).toBeDefined();
+  });
+
+  test('fetches domain info for invalid domain', async () => {
+    const domainInfo = await fetchDomainInfo('invalid.invalid');
+    expect(domainInfo).toBeUndefined();
+  });
+
+  test('fetches domain info for empty domain', async () => {
+    const domainInfo = await fetchDomainInfo('');
+    expect(domainInfo).toBeUndefined();
+  });
+
 });
 
+describe ('Values of DomainInfo are correct', () => {
+  test('fetches domain info for baklouti.de', async () => {
+    const domainInfo = await fetchDomainInfo('baklouti.de');
+    expect(domainInfo?.sslData).toBeDefined();
+    expect(domainInfo?.serverData).toBeDefined();
+    expect(domainInfo?.dnsData).toBeDefined();
+    expect(domainInfo?.httpStatus).toBeDefined();
+    expect(domainInfo?.httpStatus).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## [1.1.0] - 2023-05-23

### Breaking

- The `IDomainInfo` interface has been renamed to `DomainInfo` so the `fetchDomainInfo` function now returns a `DomainInfo` object instead of an `IDomainInfo` object.

### Updated

- Updated the README.md
- Updated the package.json keywords
- Updated the package.json description
- Updated the installed packages to the latest version

### Added

- New HTTP Status Codes to the DomainInfo Object
- Domains will now be formatted to lowercase before fetching the information
- Domains that start with `http://`, `https://` or `www` will now be stripped of the protocol before fetching the information
- New Tests for the new HTTP Status Codes